### PR TITLE
ADD clean way to try delete namespace before try the hard way

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This tool is aimed to kill namespaces that stuck in Terminating mode after you try to delete it.
 
+It automate the tips by @alvaroaleman em https://github.com/kubernetes/kubernetes/issues/60807#issuecomment-524772920
+If it doesn't work for you, please, let me know. It is hard to force namespace in Terminating mode just to test it.
+
 ### Just call the script on an host that manage your Kubernetes (kubectl configured)
 
 #### with CURL

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This tool is aimed to kill namespaces that stuck in Terminating mode after you try to delete it.
 
-It automate the tips by @alvaroaleman em https://github.com/kubernetes/kubernetes/issues/60807#issuecomment-524772920
+It automate the tips by @alvaroaleman in https://github.com/kubernetes/kubernetes/issues/60807#issuecomment-524772920
 If it doesn't work for you, please, let me know. It is hard to force namespace in Terminating mode just to test it.
 
 ### Just call the script on an host that manage your Kubernetes (kubectl configured)

--- a/knsk.sh
+++ b/knsk.sh
@@ -10,41 +10,74 @@
 #
 # ----------------------------------------------------------------------------
 
+# Ensure declaration of variables before use it
 set -u
+
+# Short for kubectl
 k=kubectl
 
-echo -n "Testing if kubectl is configured... "
+echo "\nknsk\tThis script tries to kill stucked namespaces\n"
+echo -n "\t- Testing if kubectl is configured... "
+$k cluster-info > /dev/null 2>&1; error=$?
+if [ $error -gt 0 ]; then
+  echo "error, I can't execute kubectl on this machine!\n"
+  exit 1
+else
+  echo "ok!\n"
+fi
 
-  $k cluster-info > /dev/null 2>&1; error=$?
-
-  if [ $error -gt 0 ]; then
-    echo "error, I can't execute kubectl on this machine!"
-    exit 1
-  else
-    echo "ok!"
-  fi
-
-echo -n "Looking for namespaces in 'Terminating' status... "
-
+echo -n "\t- Checking for namespaces with 'Terminating' status... "
   namespace=$($k get ns 2>/dev/null | grep Terminating | cut -f1 -d ' ')
-  # namespace=apim
+  namespace="testea default testeb"
+  if [ "x$namespace" != "x" ]; then echo "found!"
 
-  if [ "x$namespace" != "x" ]; then
+    # Found namespaces in Terminating mode, listen it
+    # Cheking what can be wrong
+    
+    # Check if any namespaced pendencies that blocks namespace deletion
+    # It is a clean deletion, as suggested by https://github.com/kubernetes/kubernetes/issues/60807#issuecomment-524772920
+    echo -n "\n\t- Cheking if exists any apiservice unavailable... "
+    apiservices=$($k get apiservice | grep False | cut -f1 -d ' ')  
+    if [ "x$apiservices" != "x" ]; then echo "found!"
+      echo "\n\t  ==>\tPlease, verifiy if the resources bellow can be deleted.\n"
+      echo "\t\tIf so, delete the resourses, wait 5 minutes, and run this script again. To delete, run: \n"
+      for apiservice in $apiservices; do echo "\t\t$k delete $apiservice "; done
+      echo "\n\t\tif you want to force the deletion whitout delete the bad apiresources (not recommended),"
+      echo "\t\tplease, call this script with the flag --force."
+    else 
+      echo "not found!"
+    fi
 
-    # Found namespaces in Terminating mode
-    echo "found!"
+    # Finding all resources that still exist in namespace
+    for n in $namespace; do 
+    
+      echo -n "\n\t  => Cheking resources in namespace $n... "
+      resources=$($k api-resources --verbs=list --namespaced -o name | \
+                  xargs -n 1 $k get -n $n --no-headers=true --show-kind=true 2>/dev/null | \
+                  cut -f1 -d ' ')
+      if [ "x$resources" != "x" ]; then echo "found!"
+        echo "\n\t  ==>\tPlease, verifiy if the resources bellow can be deleted.\n"
+        echo "\t\tIf so, delete the resourses, wait 5 minutes, and run this script again. To delete, run: \n"
+        for resource in $resources; do echo "\t\t$k -n $n delete $resource "; done
+        echo "\n\t\tif you want to force the deletion whitout delete these resources (not recommended),"
+        echo "\t\tplease, call this script with the flag --force."
+      else 
+        echo "not found!"
+      fi                  
 
-    echo -n "Getting the access token... "
+    done
 
+    # Try to get the access token
+    echo -n "\n\t- Getting the access token... "
       t=$($k -n default describe secret \
         $($k -n default get secrets | grep default | cut -f1 -d ' ') | \
         grep -E '^token' | cut -f2 -d':' | tr -d '\t' | tr -d ' '); error=$?
 
-      if [ $error -gt 0 ]; then
-        echo "error, I can't get the token!"
+      if [ $error -gt 0 ]; then 
+        echo "error, I can't get the token!\n"
         exit 1
       else
-        echo "ok!"
+        echo "ok!\n"
       fi
 
   # start the kubeclt proxy


### PR DESCRIPTION
This version has a clean way to delete the stucked namespace before try to force the deletion.

It follows the @alvaroaleman tips in https://github.com/kubernetes/kubernetes/issues/60807#issuecomment-524772920