### PR TITLE
Add local testing instructions and sample workloads for backup/restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,36 @@ backup.sh [namespace] [options]
   --outdir, -o <path>     Write output to this directory instead of the default knsk_backup/<timestamp>/
 ```
 
+### Testing locally
+
+A `test_scripts.yaml` file is included to spin up sample workloads across three namespaces (`team-a`, `team-b`, `team-c`) and verify the full backup/restore cycle:
+
+```bash
+# 1. Deploy test resources
+kubectl apply -f test_scripts.yaml
+
+# 2. Run a full-cluster backup
+./backup.sh
+
+# 3. Delete the test namespaces
+kubectl delete ns team-a team-b team-c
+
+# 4. Restore from backup (replace the timestamp with the one generated in step 2)
+kubectl apply -f knsk_backup/<timestamp>/team-a/
+kubectl apply -f knsk_backup/<timestamp>/team-b/
+kubectl apply -f knsk_backup/<timestamp>/team-c/
+```
+
+Expected result: all namespaces, Deployments, ConfigMaps, Secrets, Services, StatefulSets, PersistentVolumes, PersistentVolumeClaims, and Jobs are recreated cleanly with no errors.
+
+> **Intentional edge case:** `team-b` contains a PVC that will end up in `Lost` phase after restore — the backing PV is recreated but the binding reference no longer matches. This is by design, to exercise `knsk.sh --delete-lost`. Run the following to clean it up and allow the StatefulSet pods to schedule:
+>
+> ```bash
+> ./knsk.sh --delete-lost
+> ```
+>
+> After this step, all scripts have been fully tested end-to-end.
+
 ### Requirements
 
 | Tool | Required by | Install |

--- a/backup.sh
+++ b/backup.sh
@@ -48,7 +48,34 @@ fi
   SYS_NS="^(kube-system|kube-public|kube-node-lease)$"
 
   # yq expression that strips all k8s-managed fields so the YAML is safe for 'kubectl apply'
-  YQ_DEL='del(.status, .metadata.uid, .metadata.resourceVersion, .metadata.generation, .metadata.creationTimestamp, .metadata.deletionTimestamp, .metadata.deletionGracePeriodSeconds, .metadata.selfLink, .metadata.managedFields, .metadata.ownerReferences, .metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"], .metadata.annotations["pv.kubernetes.io/bind-completed"], .metadata.annotations["pv.kubernetes.io/bound-by-controller"])'
+  YQ_DEL='del(.status)'
+  YQ_DEL+=' | del(.metadata.uid)'
+  YQ_DEL+=' | del(.metadata.resourceVersion)'
+  YQ_DEL+=' | del(.metadata.generation)'
+  YQ_DEL+=' | del(.metadata.creationTimestamp)'
+  YQ_DEL+=' | del(.metadata.deletionTimestamp)'
+  YQ_DEL+=' | del(.metadata.deletionGracePeriodSeconds)'
+  YQ_DEL+=' | del(.metadata.selfLink)'
+  YQ_DEL+=' | del(.metadata.managedFields)'
+  YQ_DEL+=' | del(.metadata.ownerReferences)'
+
+  # Job-specific: strip auto-generated selector and pod-template labels tied to the original UID
+  YQ_DEL_JOB="$YQ_DEL"
+  YQ_DEL_JOB+=' | del(.spec.selector)'
+  YQ_DEL_JOB+=' | del(.spec.template.metadata.labels["batch.kubernetes.io/controller-uid"])'
+  YQ_DEL_JOB+=' | del(.spec.template.metadata.labels["batch.kubernetes.io/job-name"])'
+  YQ_DEL_JOB+=' | del(.spec.template.metadata.labels["controller-uid"])'
+  YQ_DEL_JOB+=' | del(.spec.template.metadata.labels["job-name"])'
+  YQ_DEL_JOB+=' | del(.metadata.labels["batch.kubernetes.io/controller-uid"])'
+  YQ_DEL_JOB+=' | del(.metadata.labels["batch.kubernetes.io/job-name"])'
+  YQ_DEL_JOB+=' | del(.metadata.labels["controller-uid"])'
+  YQ_DEL_JOB+=' | del(.metadata.labels["job-name"])'
+
+  # PV-specific: strip annotations set by the PV/PVC bind controller
+  YQ_DEL_PV="$YQ_DEL"
+  YQ_DEL_PV+=' | del(.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])'
+  YQ_DEL_PV+=' | del(.metadata.annotations["pv.kubernetes.io/bind-completed"])'
+  YQ_DEL_PV+=' | del(.metadata.annotations["pv.kubernetes.io/bound-by-controller"])'
 
 # Function to format and print messages
   pp () {
@@ -138,6 +165,7 @@ fi
       # PVCs: also strip spec.volumeName so the claim is not bound to a non-existent PV on restore
       local YQ_EXPR="$YQ_DEL"
       [[ "$KIND" == "PersistentVolumeClaim" ]] && YQ_EXPR="${YQ_DEL} | del(.spec.volumeName)"
+      [[ "$KIND" == "Job"                   ]] && YQ_EXPR="$YQ_DEL_JOB"
       kubectl get "$RESOURCE" "$NAME" -n "$NS" -o yaml 2>/dev/null | \
         yq "$YQ_EXPR" > "$OUTFILE" 2>/dev/null
       if [ -s "$OUTFILE" ]; then
@@ -163,7 +191,7 @@ fi
       [ -z "$PV_NAME" ] && continue
       pp t2n "pv/$PV_NAME"
       local OUTFILE="$OUTDIR/$NS/PersistentVolume-$PV_NAME.yaml"
-      local YQ_EXPR="$YQ_DEL"
+      local YQ_EXPR="$YQ_DEL_PV"
       kubectl get pv "$PV_NAME" -o yaml 2>/dev/null | \
         yq "$YQ_EXPR" > "$OUTFILE" 2>/dev/null
       if [ -s "$OUTFILE" ]; then

--- a/test_scripts.yaml
+++ b/test_scripts.yaml
@@ -1,0 +1,243 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-a
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-b
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-c
+
+# -------------------------------------------------
+# TEAM A RESOURCES
+# -------------------------------------------------
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: team-a
+data:
+  APP: "team-a"
+  ENV: "dev"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-a
+  namespace: team-a
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web-a
+  template:
+    metadata:
+      labels:
+        app: web-a
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-a-svc
+  namespace: team-a
+spec:
+  selector:
+    app: web-a
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker-a
+  namespace: team-a
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: worker-a
+  template:
+    metadata:
+      labels:
+        app: worker-a
+    spec:
+      containers:
+        - name: busybox
+          image: busybox
+          command: ["sh", "-c", "while true; do echo team-a working; sleep 15; done"]
+
+# -------------------------------------------------
+# TEAM B RESOURCES
+# -------------------------------------------------
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-secret
+  namespace: team-b
+type: Opaque
+stringData:
+  password: "team-b-pass"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-b
+  namespace: team-b
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-b
+  namespace: team-b
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api-b
+  template:
+    metadata:
+      labels:
+        app: api-b
+    spec:
+      containers:
+        - name: app
+          image: alpine
+          command: ["sh", "-c", "while true; do sleep 20; done"]
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-secret
+                  key: password
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db-b
+  namespace: team-b
+spec:
+  serviceName: db-b-svc
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db-b
+  template:
+    metadata:
+      labels:
+        app: db-b
+    spec:
+      containers:
+        - name: db
+          image: redis:7
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: db-b-svc
+  namespace: team-b
+spec:
+  clusterIP: None
+  selector:
+    app: db-b
+  ports:
+    - port: 6379
+      targetPort: 6379
+
+# -------------------------------------------------
+# TEAM C RESOURCES
+# -------------------------------------------------
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-c
+  namespace: team-c
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend-c
+  template:
+    metadata:
+      labels:
+        app: frontend-c
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-c-svc
+  namespace: team-c
+spec:
+  selector:
+    app: frontend-c
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-c
+  namespace: team-c
+spec:
+  template:
+    spec:
+      containers:
+        - name: job
+          image: busybox
+          command: ["sh", "-c", "echo Hello from team-c job"]
+      restartPolicy: Never


### PR DESCRIPTION
### Testing locally

A `test_scripts.yaml` file is included to spin up sample workloads across three namespaces (`team-a`, `team-b`, `team-c`) and verify the full backup/restore cycle:

```bash
# 1. Deploy test resources
kubectl apply -f test_scripts.yaml

# 2. Run a full-cluster backup
./backup.sh

# 3. Delete the test namespaces
kubectl delete ns team-a team-b team-c

# 4. Restore from backup (replace the timestamp with the one generated in step 2)
kubectl apply -f knsk_backup/<timestamp>/team-a/
kubectl apply -f knsk_backup/<timestamp>/team-b/
kubectl apply -f knsk_backup/<timestamp>/team-c/
```

Expected result: all namespaces, Deployments, ConfigMaps, Secrets, Services, StatefulSets, PersistentVolumes, PersistentVolumeClaims, and Jobs are recreated cleanly with no errors.

> **Intentional edge case:** `team-b` contains a PVC that will end up in `Lost` phase after restore — the backing PV is recreated but the binding reference no longer matches. This is by design, to exercise `knsk.sh --delete-lost`. Run the following to clean it up and allow the StatefulSet pods to schedule:
>
> ```bash
> ./knsk.sh --delete-lost
> ```
>
> After this step, all scripts have been fully tested end-to-end.